### PR TITLE
Fix multiple bugs on the jailbreak pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "appledb"]
 	path = appledb
-	url = https://github.com/emiyl/appledb
+	url = https://github.com/littlebyteorg/appledb
 [submodule "emiyl-theme"]
 	path = emiyl-theme
 	url = https://github.com/emiyl/emiyl-theme

--- a/docs/.vuepress/plugins/jailbreakPages/lib/jailbreakPages.js
+++ b/docs/.vuepress/plugins/jailbreakPages/lib/jailbreakPages.js
@@ -163,7 +163,7 @@ for (const jb of jbList) {
 
         return x
       })
-
+      .filter(x => x.firmwares.length > 0);
       return devList
     }
 


### PR DESCRIPTION
Changes include:

1. Fixing duplication of builds in jailbreak tables
2. Fixing some iPhone sections having too many devices (IE `iPhone 6 Plus` showing up in the `iPhone 6` section)
3. Fixed sorting of releases (I interpreted the code as needing to be in descending order, but I can easily flip this to be ascending order instead)
4. Fixed some versions just not showing up because multiple versions with the same build exist
5. Fixed an edge case where the jailbreak `firmwares` array only had one value, resulting in the site showing `undefined` as the latest supported version

I also adjusted the AppleDB submodule to be in the `littlebyteorg` organization.