### PR TITLE
Add decryption keys to pages linking to encrypted download files

### DIFF
--- a/docs/.vuepress/components/components/buttons/buttons.vue
+++ b/docs/.vuepress/components/components/buttons/buttons.vue
@@ -14,6 +14,10 @@
                 :index="index" 
                 :length="content.length
             "/>
+            <template v-if="item.decryptionKey">
+                <h5>Decryption Key</h5>
+                <code>{{ item.decryptionKey }}</code>
+            </template>
         </div>
     </div>
 </template>

--- a/docs/.vuepress/components/components/grid/grid.vue
+++ b/docs/.vuepress/components/components/grid/grid.vue
@@ -7,8 +7,7 @@
             v-for="i in content"
             :key="i.key"
         >
-            <a v-if="i.link" :href="i.link"><gridElement :sectionClass="sectionClass" class="gridElement" :content="i"/></a>
-            <gridElement v-else :sectionClass="sectionClass" :content="i"/>
+            <gridElement :sectionClass="sectionClass" class="gridElement" :content="i"/>
         </template>
     </div>
 </template>

--- a/docs/.vuepress/components/components/grid/gridElement.vue
+++ b/docs/.vuepress/components/components/grid/gridElement.vue
@@ -11,7 +11,10 @@
             </template>
         </div>
         <div class="text">
-            <div class="title">{{ content.title }}</div>
+            <div class="title">
+                <a v-if="content.link" :href="content.link">{{ content.title }}</a>
+                <template v-else>{{ content.title }}</template>
+            </div>
             <div class="subtitle">
                 {{ content.subtitle }}
                 <div class="iconRow" v-if="content.icons">
@@ -22,6 +25,10 @@
                         <li v-for="link in content.links" :key="link">
                             <a v-if="link.link" :href="link.link"><i v-if="link.icon" :class="link.icon"></i> {{ link.text }}</a>
                             <template v-else><i v-if="link.icon" :class="link.icon"></i> {{ link.text }}</template>
+                            <template v-if="link.decryptionKey">
+                                <i class="fa fa-key" @click.stop="controlVisibility(link.link)" />
+                                <div :style="visibleKeys.includes(link.link) ? '' : 'display: none'">Decryption Key:<code>{{ link.decryptionKey }}</code></div>
+                            </template>
                         </li>
                     </ul>
                 </div>
@@ -40,6 +47,7 @@ export default {
     },
     data() {
         return {
+            visibleKeys: [],
             isDarkMode: useDarkMode()
         }
     },
@@ -57,6 +65,15 @@ export default {
                 const dark = (imgName.dark && this.isDarkMode) ? '_dark' : ''
 
                 return [baseUrl,imgKey,imgName.id+dark].join('/')
+            }
+        }
+    },
+    methods: {
+        controlVisibility(itemLink) {
+            if (this.visibleKeys.includes(itemLink)) {
+                this.visibleKeys = this.visibleKeys.filter(x => x != itemLink)
+            } else {
+                this.visibleKeys.push(itemLink)
             }
         }
     }
@@ -84,6 +101,15 @@ export default {
         font-size: 1.2em;
         padding-bottom: 6px;
         width: calc(100% - 2em);
+
+        a {
+            color: var(--c-text);
+            font-weight: 600;
+
+            &:hover {
+                text-decoration: initial;
+            }
+        }
     }
 
     .links {


### PR DESCRIPTION
Breaking change: the full box can't be a link anymore as clicking the key icon just redirects to the device page instead. I've changed it to just be the link, which is why I'm throwing it up as a PR. There's probably a way to do it, but I've not been able to figure it out (yet)

<img width="379" height="330" alt="image" src="https://github.com/user-attachments/assets/a2ca4c6b-7ca9-423e-84a6-c7e860f00d6b" />

